### PR TITLE
feat: RabbitMQ 리스너에 큐 및 교환 설정 추가

### DIFF
--- a/src/main/java/com/couponpop/notificationservice/common/rabbitmq/consumer/CouponUsageStatsFcmSendEventConsumer.java
+++ b/src/main/java/com/couponpop/notificationservice/common/rabbitmq/consumer/CouponUsageStatsFcmSendEventConsumer.java
@@ -5,6 +5,9 @@ import com.couponpop.notificationservice.common.rabbitmq.dto.request.CouponUsage
 import com.couponpop.notificationservice.domain.notification.constants.NotificationTemplates;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.Exchange;
+import org.springframework.amqp.rabbit.annotation.Queue;
+import org.springframework.amqp.rabbit.annotation.QueueBinding;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
@@ -16,8 +19,12 @@ import java.util.List;
 public class CouponUsageStatsFcmSendEventConsumer {
 
     private final FcmSendService fcmSendService;
-
-    @RabbitListener(queues = "${rabbitmq.coupon-usage-stats-fcm-send.queue}")
+    
+    @RabbitListener(bindings = @QueueBinding(
+            value = @Queue(value = "${rabbitmq.coupon-usage-stats-fcm-send.queue}", durable = "true"),
+            exchange = @Exchange(value = "${rabbitmq.coupon-usage-stats-fcm-send.exchange}", type = "direct"),
+            key = "${rabbitmq.coupon-usage-stats-fcm-send.routing-key}"
+    ))
     public void handle(CouponUsageStatsFcmSendRequest message) {
         try {
             log.info("쿠폰 사용 통계 FCM 요청 수신: {}", message);


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호

<br>

## 📝 **작업 내용**

- RabbitMQ 리스너에 큐 및 교환 설정 추가
   - exchange가 없을 때 앱 실행이 안되는 오류

<br>

## 📸 **스크린샷 (선택)**

<br>
